### PR TITLE
Nhse o34 or.i4 loggercfg

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -28,6 +28,8 @@ jobs:
         uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ matrix.otp }}
+      - name: Install pam
+        run: sudo apt install -y libpam0g-dev
       - name: Compile
         run: ./rebar3 compile
       - name: Run xref and dialyzer

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -1,0 +1,36 @@
+name: Erlang CI
+
+on:
+  push:
+    branches:
+      - openriak-3.4
+  pull_request:
+    branches:
+      - openriak-3.4
+
+jobs:
+
+  build:
+
+    name: Test on ${{ matrix.os }} with OTP ${{ matrix.otp }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        otp: [26]
+        os: [ubuntu-latest]
+
+    steps:
+      - uses: lukka/get-cmake@latest
+      - uses: actions/checkout@v4
+      - name: Install Erlang/OTP
+        uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{ matrix.otp }}
+      - name: Compile
+        run: ./rebar3 compile
+      - name: Run xref and dialyzer
+        run: ./rebar3 do xref, dialyzer
+      - name: Run eunit
+        run: ./rebar3 as gha do eunit

--- a/apps/riak/src/riak.app.src
+++ b/apps/riak/src/riak.app.src
@@ -6,7 +6,6 @@
        kernel,
        stdlib,
        tools,
-       syslogger,
        public_key,
        ssl,
        os_mon,

--- a/priv/riak.schema
+++ b/priv/riak.schema
@@ -14,9 +14,50 @@
   {default, "[time,\" [\",level,\"] \",pid,\"@\",mfa,\":\",line,\" \",msg,\"\\n\"]."}
 ]}.
 
-%% @doc Filename to use for log files.
+%% @doc Filename to use for default log file.
 {mapping, "logger.file", "kernel.logger", [
   {default, "$(platform_log_dir)/console.log"},
+  {datatype, file}
+]}.
+
+%% @doc filename to be used for error log file (if configured)
+{mapping, "logger.error_file", "kernel.logger", [
+  {default, "$(platform_log_dir)/error.log"},
+  {datatype, file}
+]}.
+
+%% @doc filename to be used for crash log file (if configured)
+{mapping, "logger.crash_file", "kernel.logger", [
+  {default, "$(platform_log_dir)/crash.log"},
+  {datatype, file}
+]}.
+
+%% @doc filename to be used for report log file (if configured)
+{mapping, "logger.report_file", "kernel.logger", [
+  {default, "$(platform_log_dir)/report.log"},
+  {datatype, file}
+]}.
+
+%% @doc filename to be used for backend log file (if configured)
+%% The backend log can be used to divert leveled backend logs away from the
+%% default logger file
+{mapping, "logger.backend_file", "kernel.logger", [
+  {default, "$(platform_log_dir)/backend.log"},
+  {datatype, file}
+]}.
+
+%% @doc filename to be used for background log file (if configured)
+%% The background log can be used to divert tictacaae and timer-based metric
+%% logs away from the default logger file
+{mapping, "logger.background_file", "kernel.logger", [
+  {default, "$(platform_log_dir)/background.log"},
+  {datatype, file}
+]}.
+
+%% @doc filename to be used for json log file (if configured)
+%% The json file can be used to capture all logs in a json format
+{mapping, "logger.json_file", "kernel.logger", [
+  {default, "$(platform_log_dir)/json.log"},
   {datatype, file}
 ]}.
 
@@ -34,36 +75,72 @@
   {datatype, bytesize}
 ]}.
 
+%% @doc Default filters
+%% A '|' delimited list of filters which will cause logs to be diverted from
+%% the common `logger.file` into other log files.
+%%
+%% The supported options are crash, error, progress, report, sasl, backend or
+%% background.
+%%
+%% Where these filters are applied, the logs will be ignored unless additional
+%% handlers are defined as a location for the filtered logs within
+%% `logger.additional_handlers`.
+%%
+%% e.g. "logger.default_filters = crash|error|progress|sasl|backend|background"
+{mapping, "logger.default_filters", "kernel.logger", [
+  {default, ""},
+  {commented, ""},
+  {validators, ["default_filters"]}
+]}.
+
+{validator,
+ "default_filters",
+ "must be a '|' list containing only crash, error, progress, report, sasl, backend or background",
+ fun(PipedList) ->
+    AtomList = string:lexemes(PipedList, "|"),
+    Candidates =
+      ["crash", "error", "progress", "report", "sasl", "backend", "background"],
+    lists:all(fun(A) -> lists:member(A, Candidates) end, AtomList)
+ end}.
+
+%% @doc Additional Handlers
+%% A '|' delimited list of additional handlers which will be used to handle
+%% logs of specific types.
+%%
+%% Supported additional handlers are crash, error, report, backend, background
+%% and json.
+%%
+%% For non-json handlers, only specific logs related to that handler will be
+%% logged into the related file.  For the json handler all logs will be stored
+%% (but in a json format)
+%%
+%% e.g. logger.additional_handlers = crash|error|report|backend|background
+{mapping, "logger.additional_handlers", "kernel.logger", [
+  {default, ""},
+  {commented, ""},
+  {validators, ["additional_handlers"]}
+]}.
+
+{validator,
+ "additional_handlers",
+ "must be a '|' list containing only crash, error, report, backend, background or json",
+ fun(PipedList) ->
+    AtomList = string:lexemes(PipedList, "|"),
+    Candidates =
+      ["crash", "error", "report", "backend", "background", "json"],
+    lists:all(fun(A) -> lists:member(A, Candidates) end, AtomList)
+ end
+ }.
+
 {translation,
  "kernel.logger",
  fun(Conf) ->
-    LogFile = cuttlefish:conf_get("logger.file", Conf),
-    MaxNumBytes = cuttlefish:conf_get("logger.max_file_size", Conf),
-    MaxNumFiles = cuttlefish:conf_get("logger.max_files", Conf),
-
-    DefaultFormatStr = cuttlefish:conf_get("logger.format", Conf),
-    DefaultFormatTerm =
-        case erl_scan:string(DefaultFormatStr) of
-            {ok, DefaultTokens, _} ->
-                case erl_parse:parse_term(DefaultTokens) of
-                    {ok, DefaultTerm} ->
-                        DefaultTerm;
-                    {error, {_, _, DefaultError}} ->
-                        cuttlefish:error(foo)
-                end;
-            {error, {_, _, DefaultScanError}} ->
-                cuttlefish:error(foo)
-        end,
-    ConfigMap0 = #{config => #{file => LogFile,
-                              max_no_bytes => MaxNumBytes,
-                              max_no_files => MaxNumFiles},
-                  formatter => {logger_formatter, 
-                                    #{template => DefaultFormatTerm}
-                               }
-                 },
-
-    [{handler, default, logger_std_h, ConfigMap0}]
-    
+    case riak_logger_config:handler_config(Conf, fun cuttlefish:conf_get/2) of
+      {ok, Handlers} ->
+        Handlers;
+      Error ->
+        Error
+    end
   end
 }.
 

--- a/priv/riak.schema
+++ b/priv/riak.schema
@@ -76,8 +76,8 @@
 ]}.
 
 %% @doc Default filters
-%% A '|' delimited list of filters which will cause logs to be diverted from
-%% the common `logger.file` into other log files.
+%% A list of log types for where logs are expected to be filtered from the
+%% common `logger.file` (i.e. console.log).
 %%
 %% The supported options are crash, error, progress, report, sasl, backend or
 %% background.
@@ -86,26 +86,21 @@
 %% handlers are defined as a location for the filtered logs within
 %% `logger.additional_handlers`.
 %%
-%% e.g. "logger.default_filters = crash|error|progress|sasl|backend|background"
+%% The backend and background filters are filters based on `domain`.  The
+%% backend filter will presently filter every log in the domain
+%% [backend, leveled].  For background, it will be [background, tictacaae] or
+%% [background, metric]
+%%
+%% The default configuration of none is used to indicate no default_filters
 {mapping, "logger.default_filters", "kernel.logger", [
-  {default, ""},
-  {commented, ""},
-  {validators, ["default_filters"]}
+  {datatype, {list, {enum, [none, crash, error, progress, report, sasl, backend, background]}}},
+  {default, "none"}
 ]}.
 
-{validator,
- "default_filters",
- "must be a '|' list containing only crash, error, progress, report, sasl, backend or background",
- fun(PipedList) ->
-    AtomList = string:lexemes(PipedList, "|"),
-    Candidates =
-      ["crash", "error", "progress", "report", "sasl", "backend", "background"],
-    lists:all(fun(A) -> lists:member(A, Candidates) end, AtomList)
- end}.
-
 %% @doc Additional Handlers
-%% A '|' delimited list of additional handlers which will be used to handle
-%% logs of specific types.
+%% A list of additional handlers which will be used to handle logs of specific
+%% types.  These handlers will duplicate logs in the default 'logger.file'
+%% (i.e. the console.log) unless there are also matching default filters.
 %%
 %% Supported additional handlers are crash, error, report, backend, background
 %% and json.
@@ -114,23 +109,11 @@
 %% logged into the related file.  For the json handler all logs will be stored
 %% (but in a json format)
 %%
-%% e.g. logger.additional_handlers = crash|error|report|backend|background
+%% The default configuration of none is used to indicate no additional_handlers
 {mapping, "logger.additional_handlers", "kernel.logger", [
-  {default, ""},
-  {commented, ""},
-  {validators, ["additional_handlers"]}
+  {datatype, {list, {enum, [none, crash, error, report, backend, background]}}},
+  {default, "none"}
 ]}.
-
-{validator,
- "additional_handlers",
- "must be a '|' list containing only crash, error, report, backend, background or json",
- fun(PipedList) ->
-    AtomList = string:lexemes(PipedList, "|"),
-    Candidates =
-      ["crash", "error", "report", "backend", "background", "json"],
-    lists:all(fun(A) -> lists:member(A, Candidates) end, AtomList)
- end
- }.
 
 {translation,
  "kernel.logger",

--- a/rebar.config
+++ b/rebar.config
@@ -7,15 +7,14 @@
 {eunit_opts, [nowarn_export_all, verbose]}.
 
 {deps, [
-        {riak_logger, {git, "https://github.com/OpenRiak/riak_logger", {branch, "nhse-wday32-or.i4-riakconf"}}},
-        {kv_index_tictactree, {git, "https://github.com/martinsumner/kv_index_tictactree", {branch, "mas-d34-or.i4-domain"}}},
+        {riak_logger, {git, "https://github.com/OpenRiak/riak_logger", {branch, "nhse-wday32-or.i4-riakconf"}}}, % TODO - revert on merge
         {riak_kv, {git, "https://github.com/OpenRiak/riak_kv", {branch, "openriak-3.4"}}},
         {riak_auth_mods, {git, "https://github.com/OpenRiak/riak_auth_mods", {branch, "openriak-3.4"}}},
         {riak_repl, {git, "https://github.com/OpenRiak/riak_repl", {branch, "openriak-3.4"}}}
       ]}.
 
 {project_plugins, [
-    {rebar3_cuttlefish, {git, "https://github.com/OpenRiak/rebar3_cuttlefish", {branch, "nhse-o32-orc.i4-branch"}}}
+    {rebar3_cuttlefish, {git, "https://github.com/OpenRiak/rebar3_cuttlefish", {branch, "nhse-o32-orc.i4-branch"}}} % TODO - revert on merge
 ]}.
 
 {cuttlefish, [

--- a/rebar.config
+++ b/rebar.config
@@ -7,14 +7,14 @@
 {eunit_opts, [nowarn_export_all, verbose]}.
 
 {deps, [
-        {riak_logger, {git, "https://github.com/OpenRiak/riak_logger", {branch, "nhse-wday32-or.i4-riakconf"}}}, % TODO - revert on merge
-        {riak_kv, {git, "https://github.com/OpenRiak/riak_kv", {branch, "nhse-o34-or.i4-logger"}}}, % TODO - revert on merge
+        {riak_logger, {git, "https://github.com/OpenRiak/riak_logger", {branch, "openriak-3.4"}}},
+        {riak_kv, {git, "https://github.com/OpenRiak/riak_kv", {branch, "openriak-3.4"}}},
         {riak_auth_mods, {git, "https://github.com/OpenRiak/riak_auth_mods", {branch, "openriak-3.4"}}},
         {riak_repl, {git, "https://github.com/OpenRiak/riak_repl", {branch, "openriak-3.4"}}}
       ]}.
 
 {project_plugins, [
-    {rebar3_cuttlefish, {git, "https://github.com/OpenRiak/rebar3_cuttlefish", {branch, "nhse-o32-orc.i4-branch"}}} % TODO - revert on merge
+    {rebar3_cuttlefish, {git, "https://github.com/OpenRiak/rebar3_cuttlefish", {branch, "openriak-3.4"}}}
 ]}.
 
 {cuttlefish, [

--- a/rebar.config
+++ b/rebar.config
@@ -7,6 +7,8 @@
 {eunit_opts, [nowarn_export_all, verbose]}.
 
 {deps, [
+        {riak_logger, {git, "https://github.com/OpenRiak/riak_logger", {branch, "nhse-wday32-or.i4-riakconf"}}},
+        {kv_index_tictactree, {git, "https://github.com/martinsumner/kv_index_tictactree", {branch, "mas-d34-or.i4-domain"}}},
         {riak_kv, {git, "https://github.com/OpenRiak/riak_kv", {branch, "openriak-3.4"}}},
         {riak_auth_mods, {git, "https://github.com/OpenRiak/riak_auth_mods", {branch, "openriak-3.4"}}},
         {riak_repl, {git, "https://github.com/OpenRiak/riak_repl", {branch, "openriak-3.4"}}}
@@ -62,7 +64,8 @@
      riak_repl,
      cluster_info,
      % riaknostic,
-     riak_auth_mods]},
+     riak_auth_mods,
+     riak_logger]},
 
     {dev_mode, false},
     {include_erts, true},

--- a/rebar.config
+++ b/rebar.config
@@ -8,7 +8,7 @@
 
 {deps, [
         {riak_logger, {git, "https://github.com/OpenRiak/riak_logger", {branch, "nhse-wday32-or.i4-riakconf"}}}, % TODO - revert on merge
-        {riak_kv, {git, "https://github.com/OpenRiak/riak_kv", {branch, "openriak-3.4"}}},
+        {riak_kv, {git, "https://github.com/OpenRiak/riak_kv", {branch, "nhse-o34-or.i4-logger"}}}, % TODO - revert on merge
         {riak_auth_mods, {git, "https://github.com/OpenRiak/riak_auth_mods", {branch, "openriak-3.4"}}},
         {riak_repl, {git, "https://github.com/OpenRiak/riak_repl", {branch, "openriak-3.4"}}}
       ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -15,7 +15,7 @@
       ]}.
 
 {project_plugins, [
-    {rebar3_cuttlefish, {git, "https://github.com/OpenRiak/rebar3_cuttlefish", {branch, "openriak-3.2"}}}
+    {rebar3_cuttlefish, {git, "https://github.com/OpenRiak/rebar3_cuttlefish", {branch, "nhse-o32-orc.i4-branch"}}}
 ]}.
 
 {cuttlefish, [

--- a/test/riak_schema_tests.erl
+++ b/test/riak_schema_tests.erl
@@ -1,0 +1,191 @@
+%% -------------------------------------------------------------------
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(riak_schema_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-compile([export_all, nowarn_export_all]).
+
+%% basic schema test will check to make sure that all defaults from the schema
+%% make it into the generated app.config
+base_riak_schema_test() ->
+    Config =
+        cuttlefish_unit:generate_templated_config(
+            ["priv/riak.schema"],
+            [],
+            context(),
+            predefined_schema()
+        ),
+    cuttlefish_unit:assert_config(
+        Config,
+        "kernel.logger_level",
+        info
+    ),
+    cuttlefish_unit:assert_config(
+        Config,
+        "kernel.logger",
+        expected_default_handler_config()
+    ),
+    cuttlefish_unit:assert_config(
+        Config,
+        "vm_args",
+        expected_default_vmargs()
+    ).
+
+advanced_logger_schema_test() ->
+    Config =
+        [
+            {
+                ["logger", "default_filters"],
+                "crash|error|progress|sasl|backend|background"
+            },
+            {
+                ["logger", "additional_handlers"],
+                "crash|error|report|backend|background"
+            }
+        ],
+    GenConfig =
+        cuttlefish_unit:generate_templated_config(
+            ["priv/riak.schema"],
+            Config,
+            context(),
+            predefined_schema()
+        ),
+    {kernel, LoggingConfig} = lists:keyfind(kernel, 1, GenConfig),
+    {logger, HandlerConfig} = lists:keyfind(logger, 1, LoggingConfig),
+    ?assertMatch(6, length(HandlerConfig)).
+
+bad_filter_schema_test() ->
+    Config =
+        [
+            {
+                ["logger", "default_filters"],
+                "crash|hesawrongun|progress|sasl|backend|background"
+            },
+            {
+                ["logger", "additional_handlers"],
+                "crash|error|report|backend|background"
+            }
+        ],
+    ErrorConfig =
+        cuttlefish_unit:generate_templated_config(
+            ["priv/riak.schema"],
+            Config,
+            context(),
+            predefined_schema()
+        ),
+    {error, validation, {errorlist, ErrorList}} = ErrorConfig,
+    [{error, {validation, {ValTest, ValReport}}}] = ErrorList,
+    ?assertMatch("logger.default_filters", ValTest),
+    ?assertMatch(
+        "must be a '|' list containing only "
+        "crash, error, progress, report, sasl, backend or background",
+        ValReport
+    ).
+
+bad_handler_schema_test() ->
+    Config =
+        [
+            {
+                ["logger", "default_filters"],
+                "crash|error|progress|sasl|backend|background"
+            },
+            {
+                ["logger", "additional_handlers"],
+                "crash|hesawrongun|report|backend|background"
+            }
+        ],
+    ErrorConfig =
+        cuttlefish_unit:generate_templated_config(
+            ["priv/riak.schema"],
+            Config,
+            context(),
+            predefined_schema()
+        ),
+    {error, validation, {errorlist, ErrorList}} = ErrorConfig,
+    [{error, {validation, {ValTest, ValReport}}}] = ErrorList,
+    ?assertMatch("logger.additional_handlers", ValTest),
+    ?assertMatch(
+        "must be a '|' list containing only "
+        "crash, error, report, backend, background or json",
+        ValReport
+    ).
+
+expected_default_vmargs() ->
+    [
+        {'+A',64},
+        {'+scl',"false"},
+        {'+sfwi',500},
+        {'+zdbbl',"32MB"},
+        {'-setcookie',"riak"},
+        {'+B',"i"}
+    ].
+
+expected_default_handler_config() ->
+    [
+        {
+            handler,
+            default,
+            logger_std_h,
+            #{
+                config => 
+                    #{
+                        file => "./log/console.log",
+                        file_check => 100,
+                        max_no_bytes => 1048576,
+                        max_no_files => 10
+                    },
+                level => all,
+                filter_default => log,
+                filters => [],
+                formatter => 
+                    {
+                        logger_formatter,
+                        #{
+                            single_line => true,
+                            legacy_header => false,
+                            template => log_template(),
+                            time_designator => $\s
+                        }
+                    }
+                }
+        }
+    ].
+
+log_template() ->
+    [time," [",level,"] ",pid,"@",mfa,":",line," ",msg,"\n"].
+
+context() ->
+    [
+        {logger_level , "info"}
+    ].
+
+predefined_schema() ->
+    Mapping =
+        cuttlefish_mapping:parse(
+            {
+                mapping,
+                "platform_log_dir",
+                "riak_core.platform_log_dir",
+                [
+                    {default, "./log"},
+                    {datatype, directory}
+                ]
+            }
+        ),
+    {[], [Mapping], []}.

--- a/test/riak_schema_tests.erl
+++ b/test/riak_schema_tests.erl
@@ -52,11 +52,11 @@ advanced_logger_schema_test() ->
         [
             {
                 ["logger", "default_filters"],
-                "crash|error|progress|sasl|backend|background"
+                "crash, error, progress, sasl, backend, background"
             },
             {
                 ["logger", "additional_handlers"],
-                "crash|error|report|backend|background"
+                "crash, error, report, backend, background"
             }
         ],
     GenConfig =
@@ -70,61 +70,6 @@ advanced_logger_schema_test() ->
     {logger, HandlerConfig} = lists:keyfind(logger, 1, LoggingConfig),
     ?assertMatch(6, length(HandlerConfig)).
 
-bad_filter_schema_test() ->
-    Config =
-        [
-            {
-                ["logger", "default_filters"],
-                "crash|hesawrongun|progress|sasl|backend|background"
-            },
-            {
-                ["logger", "additional_handlers"],
-                "crash|error|report|backend|background"
-            }
-        ],
-    ErrorConfig =
-        cuttlefish_unit:generate_templated_config(
-            ["priv/riak.schema"],
-            Config,
-            context(),
-            predefined_schema()
-        ),
-    {error, validation, {errorlist, ErrorList}} = ErrorConfig,
-    [{error, {validation, {ValTest, ValReport}}}] = ErrorList,
-    ?assertMatch("logger.default_filters", ValTest),
-    ?assertMatch(
-        "must be a '|' list containing only "
-        "crash, error, progress, report, sasl, backend or background",
-        ValReport
-    ).
-
-bad_handler_schema_test() ->
-    Config =
-        [
-            {
-                ["logger", "default_filters"],
-                "crash|error|progress|sasl|backend|background"
-            },
-            {
-                ["logger", "additional_handlers"],
-                "crash|hesawrongun|report|backend|background"
-            }
-        ],
-    ErrorConfig =
-        cuttlefish_unit:generate_templated_config(
-            ["priv/riak.schema"],
-            Config,
-            context(),
-            predefined_schema()
-        ),
-    {error, validation, {errorlist, ErrorList}} = ErrorConfig,
-    [{error, {validation, {ValTest, ValReport}}}] = ErrorList,
-    ?assertMatch("logger.additional_handlers", ValTest),
-    ?assertMatch(
-        "must be a '|' list containing only "
-        "crash, error, report, backend, background or json",
-        ValReport
-    ).
 
 expected_default_vmargs() ->
     [


### PR DESCRIPTION
A more flexible configuration for logger via `riak.conf`.

Allows for the configuration of:
- `default_filters` - logs to be filtered out of the default (console) log file.
- `additional_handlers` - additional log handlers for specific logs

Depends on a cuttlefish PR - https://github.com/OpenRiak/cuttlefish/pull/5.  Without this PR the two need configuration items would need to use a delimited string with a dedicated validator.

Depends on a `riak_logger` PR - https://github.com/OpenRiak/riak_logger/pull/3.  This does the work to translate the configuration into a valid kernel logger handler list.

As the new configuration has a unit test, a GHA CI run is added as part of the change.

To switch logs to [background, metric] changes in:

https://github.com/OpenRiak/riak_core/pull/32
https://github.com/OpenRiak/riak_kv/pull/79