### PR TITLE
Fix riak_kv_console params for tictacaae_admin after transition to clique

### DIFF
--- a/rel/files/riak-admin
+++ b/rel/files/riak-admin
@@ -620,7 +620,7 @@ The follow commands can be used to manage bucket types for the cluster:
 tictacaae_admin()
 {
     # this command will print usage in erlang code
-    rpc riak_kv_console tictacaae_cmd "$@"
+    rpc riak_kv_console command $SCRIPT tictacaae "$@"
 }
 
 


### PR DESCRIPTION
This change should have been included in #13 after transition to clique in the main PR in [riak_kv](https://github.com/OpenRiak/riak_kv/pull/31), but has slipped out.